### PR TITLE
fixed bug that didn't render svg image

### DIFF
--- a/src/canvas/Canvas.js
+++ b/src/canvas/Canvas.js
@@ -9,6 +9,7 @@ export class Canvas {
         this.domElement.setAttributeNS(null, "width", width);
         this.domElement.setAttributeNS(null, "height", height);
         this.domElement.setAttributeNS(null, "id", "canvas");
+        this.domElement.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns", svgns);
 
         // looking for a container in which the editor will reside
         this.containerDomElement = document.getElementById(canvasContainerId);


### PR DESCRIPTION
there was a bug (as seen in yesterday's demo) in which the downloaded svg didn't render in the browser. 

turns out, it was a namespacing issue. I added the correct namespace to the svg and now it works like a dream :) 
